### PR TITLE
draw_str renders non-black backgrounds better

### DIFF
--- a/monome_euro/main.c
+++ b/monome_euro/main.c
@@ -680,7 +680,7 @@ void fill_line(uint8_t line, uint8_t colour) {
 void draw_str(const char* str, uint8_t line, uint8_t colour, uint8_t background) {
     if (_HARDWARE_SCREEN == 0) return;
     if (line >= SCREEN_LINE_COUNT) return;
-    region_fill(&screen_lines[line], 0);
+    region_fill(&screen_lines[line], background);
     font_string_region_clip(&screen_lines[line], str, 0, 0, colour, background);
 }
 


### PR DESCRIPTION
Fix to address #5 